### PR TITLE
Needs validation was not in a namespace. Fixed Readme typo

### DIFF
--- a/Models/Client/Need.cs
+++ b/Models/Client/Need.cs
@@ -33,7 +33,6 @@ namespace Models
 
         }
     }
-}
 
 public class NeedsValidator : AbstractValidator<Need>
 {
@@ -70,5 +69,6 @@ public class NeedsValidator : AbstractValidator<Need>
             .MaximumLength(30)
             .WithMessage("Must be 30 characters or less");
             
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The Client Portal Application is designed for employers to be matched quickly to
 
 ## Setup Notes For Development:
   - Check the ProjectX Discord for the appsettings.json file to connect to database.
-  - When You pick a controller/user stroy to work on, please assign yourself to the associated Trello card.
+  - When You pick a controller/user story to work on, please assign yourself to the associated Trello card.
 
 ## Postman Link
 


### PR DESCRIPTION
Needs validation was not in a namespace. Added to Models namespace. Fixed typo in Readme (stroy -> story)